### PR TITLE
Slight tweaks to the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+tags

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub trait Graph: Default {
     fn nodes(&self) -> Nodes<Self::Node>;
 
     /// Get a node's neighbors.
-    fn neighbors(&self, node: Id<Self::Node>) -> Nodes<Self::Node>;
+    fn neighbors(&self, node: &Id<Self::Node>) -> EdgeReferences<Id<Self::Node>, Id<Self::Edge>>;
 
     /// Get a node's inbound and outbound edges.
     fn edges(&self, node: Id<Self::Node>) -> Edges<Self::Edge>;
@@ -195,3 +195,14 @@ impl<'a, N: 'a> Iterator for NodesMut<'a, N> {
         self.range.next()
     }
 }
+
+/// Iterator over edge _references_, which keep track of the source and
+/// target.
+#[derive(Debug)]
+pub struct EdgeReference<'a, NodeId, EdgeId> {
+    pub source: &'a NodeId,
+    pub target: &'a NodeId,
+    pub id: &'a EdgeId,
+}
+
+pub type EdgeReferences<'a, N, E> = Vec<EdgeReference<'a, N, E>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub trait GraphWriter: Graph + GraphDataWriter {
         id: Id<Self::Edge>,
         from: Id<Self::Node>,
         to: Id<Self::Node>,
-        weight: f64,
+        weight: Self::Weight,
         data: Data<Self::Edge>,
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@ pub type Data<T> = <T as GraphObject>::Data;
 /// Abstract object in a graph, eg. node or edge.
 pub trait GraphObject {
     /// Identifier of all graph objects.
-    type Id: Clone;
+    type Id;
 
     /// Local graph object data.
     type Data;
 
     /// Return the edge id.
-    fn id(&self) -> Self::Id;
+    fn id(&self) -> &Self::Id;
 
     /// Get local data.
     fn data(&self) -> &Self::Data;
@@ -75,8 +75,8 @@ pub trait GraphWriter: Graph + GraphDataWriter {
     fn add_edge(
         &mut self,
         id: Id<Self::Edge>,
-        from: Id<Self::Node>,
-        to: Id<Self::Node>,
+        from: &Id<Self::Node>,
+        to: &Id<Self::Node>,
         weight: Self::Weight,
         data: Data<Self::Edge>,
     );
@@ -90,10 +90,10 @@ pub trait GraphWriter: Graph + GraphDataWriter {
 
 pub trait GraphDataWriter: Graph {
     /// Return a mutable reference to an edge's data, to annotate the edge.
-    fn edge_data_mut(&mut self, id: Id<Self::Edge>) -> Option<&mut Data<Self::Edge>>;
+    fn edge_data_mut(&mut self, id: &Id<Self::Edge>) -> Option<&mut Data<Self::Edge>>;
 
     /// Return a mutable reference to a node's data, to annotate the node.
-    fn node_data_mut(&mut self, id: Id<Self::Node>) -> Option<&mut Data<Self::Node>>;
+    fn node_data_mut(&mut self, id: &Id<Self::Node>) -> Option<&mut Data<Self::Node>>;
 }
 
 /// A read-only graph of nodes and edges.
@@ -114,10 +114,10 @@ pub trait Graph: Default {
     type Weight;
 
     /// Get a node.
-    fn get_node(&self, id: Id<Self::Node>) -> Option<&Self::Node>;
+    fn get_node(&self, id: &Id<Self::Node>) -> Option<&Self::Node>;
 
     /// Get an edge.
-    fn get_edge(&self, id: Id<Self::Edge>) -> Option<&Self::Edge>;
+    fn get_edge(&self, id: &Id<Self::Edge>) -> Option<&Self::Edge>;
 
     /// Iterator over nodes.
     fn nodes(&self) -> Nodes<Self::Node>;
@@ -126,7 +126,7 @@ pub trait Graph: Default {
     fn neighbors(&self, node: &Id<Self::Node>) -> EdgeReferences<Id<Self::Node>, Id<Self::Edge>>;
 
     /// Get a node's inbound and outbound edges.
-    fn edges(&self, node: Id<Self::Node>) -> Edges<Self::Edge>;
+    fn edges(&self, node: &Id<Self::Node>) -> Edges<Self::Edge>;
 }
 
 /// A graph algorithm over a graph.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub trait Graph: Default {
     fn nodes(&self) -> Nodes<Self::Node>;
 
     /// Get a node's neighbors.
-    fn neighbors(&self, node: &Id<Self::Node>) -> EdgeReferences<Id<Self::Node>, Id<Self::Edge>>;
+    fn neighbors(&self, node: &Id<Self::Node>) -> EdgeRefs<Id<Self::Node>, Id<Self::Edge>>;
 
     /// Get a node's inbound and outbound edges.
     fn edges(&self, node: &Id<Self::Node>) -> Edges<Self::Edge>;
@@ -199,10 +199,10 @@ impl<'a, N: 'a> Iterator for NodesMut<'a, N> {
 /// Iterator over edge _references_, which keep track of the source and
 /// target.
 #[derive(Debug)]
-pub struct EdgeReference<'a, NodeId, EdgeId> {
-    pub source: &'a NodeId,
-    pub target: &'a NodeId,
+pub struct EdgeRef<'a, NodeId, EdgeId> {
+    pub from: &'a NodeId,
+    pub to: &'a NodeId,
     pub id: &'a EdgeId,
 }
 
-pub type EdgeReferences<'a, N, E> = Vec<EdgeReference<'a, N, E>>;
+pub type EdgeRefs<'a, N, E> = Vec<EdgeRef<'a, N, E>>;


### PR DESCRIPTION
This PR performs slight modifications to the main API, in order to have `osrank` compile against it.

In particular, I have used references whenever possible to avoid unnecessary clones, and modified a bit the `neighbors` function to make it slightly more ergonomic for osrank. On the latter, I am open to discuss alternative approaches, as I do agree that the original API which yielded a `Nodes` type felt more right. One middle ground could be to leave `neighbors` return a `Nodes` like before, but extend `edges` to return something a bit more usable for `osrank`. As we are interested mostly in outgoing edges for a node, having something we can consume easily might be preferable.

I think that petgraph [gets it right](https://docs.rs/petgraph/0.4.13/petgraph/graph/struct.Graph.html#method.edges_directed), 
where you can pass a `Direction` as input so that internally a filter is performed and only relevant edges are returned.

Let's discuss!

(See also: https://github.com/oscoin/osrank-rs/pull/56 )
