### PR TITLE
Extend the GraphAlgorithm trait to be more osrank-friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,3 @@ name = "oscoin-graph-api"
 version = "0.1.0"
 authors = ["Alexis Sellier <alexis@monadic.xyz>"]
 edition = "2018"
-
-[dependencies]
-rand = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #[deny(clippy::all)]
 ///! Graph API Traits
 ///
-use rand::SeedableRng;
 
 #[allow(dead_code)]
 /// A graph layer name.
@@ -45,9 +44,6 @@ pub trait GraphAPI {
     /// The underlying graph.
     type Graph: GraphWriter;
 
-    /// Entropy used to seed the CPRNG.
-    type Entropy;
-
     /// Add a graph layer.
     fn add_layer(&mut self, layer: Layer);
 
@@ -59,9 +55,6 @@ pub trait GraphAPI {
 
     /// Return the mutable graph of the given layer.
     fn graph_mut(&mut self, layer: &Layer) -> Option<&mut Self::Graph>;
-
-    /// Given initial entropy, returns a random seed.
-    fn seed<R: SeedableRng>(&mut self, entropy: Self::Entropy) -> R::Seed;
 }
 
 pub trait GraphWriter: Graph + GraphDataWriter {
@@ -146,14 +139,17 @@ where
     /// An execution error.
     type Error;
 
+    /// A `Seed`, suitable to generate a `Rng`.
+    type RngSeed;
+
     /// Execute an algorithm over a context and graph.
     /// Changes to the context will be persisted across
     /// executions of the algorithm.
-    fn execute<R: SeedableRng>(
+    fn execute(
         &self,
         context: &mut Self::Context,
         graph: &mut G,
-        rng: R,
+        initial_seed: Self::RngSeed,
     ) -> Result<Self::Output, Self::Error>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ where
         &self,
         context: &mut Self::Context,
         graph: &mut G,
-        initial_seed: Self::RngSeed,
+        seed: Self::RngSeed,
     ) -> Result<Self::Output, Self::Error>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ where
     /// An execution error.
     type Error;
 
-    /// A `Seed`, suitable to generate a `Rng`.
+    /// A seed suitable for an RNG.
     type RngSeed;
 
     /// Execute an algorithm over a context and graph.


### PR DESCRIPTION
This PR does two things:

* If fixes the type errors in `main.rs` which were a oversight of the previous PR;
* If changes ever so slightly the `GraphAlgorithm` trait to make it useable within `osrank`.

Initially I did play with having the `R` type parameter being at the "outside" (as in `GraphAlgorithm<R>`), but I think it makes more sense to have it as an associated type. Furthermore, I think that passing the _full_ `SeedableRng` it's way too heavy (even just for a serialisation perspective) -- I think we can feed a `GraphAlgoritm` with an initial seed, and then have the algorithm generate the `SeedableRng` internally.

@cloudhead You can take a look at how everything fit together in this WIP PR here: https://github.com/oscoin/osrank-rs/pull/59 . It does work, but the overall API still feel a bit weird. I cannot vocalise exactly what it is, but perhaps you can tell me what you think.