### PR TITLE
Add GraphAnnotator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #[deny(clippy::all)]
 ///! Graph API Traits
-///
-
-#[allow(dead_code)]
 
 /// Specifies a direction for an edge.
 #[derive(Debug, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,10 @@ pub trait GraphDataWriter: Graph {
 pub trait GraphAnnotator {
     type Annotation;
 
-    /// Annotate the graph with some data.
+    /// Annotate the graph with some data. This is left intentionally abstract,
+    /// for the implementation to decide whether to expose a key/value like
+    /// interface with eg. `Annotation = (Key, Val)` or a batched interface
+    /// like `Annotation = Vec<(Key, Val)>`.
     fn annotate_graph(&mut self, note: Self::Annotation);
 }
 


### PR DESCRIPTION
This allows for the `GraphAlgorithm` to annotate the
graph in an implementation-defined way. For example,
one could use:

    type Annotation = (NodeId, f64);

To annotate the graph nodes with a weight.