### PR TITLE
Make certain types more polymorphic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 
-quickcheck = "*"
 num-traits = "*"
+quickcheck = { version = "*", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 
 quickcheck = "*"
+num-traits = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ name = "oscoin-graph-api"
 version = "0.1.0"
 authors = ["Alexis Sellier <alexis@monadic.xyz>"]
 edition = "2018"
+
+[dependencies]
+
+quickcheck = "*"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -225,7 +225,7 @@ impl oscoin::GraphWriter for Network {
                 to: *to,
                 weight: 0.0,
                 data,
-                edge_type: types::EdgeType::Contrib,
+                edge_type: types::EdgeType::ContributionFromUser,
             },
         );
     }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -336,14 +336,14 @@ mod ledger {
                     self::edge_id(node_id, c.node_id),
                     &node_id,
                     &c.node_id,
-                    types::EdgeType::ContributionFromUser,
+                    types::EdgeType::ProjectToUserContribution,
                 );
                 // Add `contribution -> project` link.
                 graph.add_edge(
                     self::edge_id(node_id, c.node_id),
                     &c.node_id,
                     &node_id,
-                    types::EdgeType::ContributionToProject,
+                    types::EdgeType::UserToProjectContribution,
                 );
             }
         }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -360,14 +360,14 @@ mod ledger {
                     self::edge_id(node_id, c.node_id),
                     &node_id,
                     &c.node_id,
-                    types::EdgeType::ProjectToUserContribution,
+                    types::EdgeType::ProjectToUserContribution(c.contributions),
                 );
                 // Add `contribution -> project` link.
                 graph.add_edge(
                     self::edge_id(node_id, c.node_id),
                     &c.node_id,
                     &node_id,
-                    types::EdgeType::UserToProjectContribution,
+                    types::EdgeType::UserToProjectContribution(c.contributions),
                 );
 
                 // increment the total contributions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,17 @@ pub trait GraphObject {
 }
 
 /// A graph  node.
-pub trait Node<N>: GraphObject<Data = N> {}
+pub trait Node<N>: GraphObject<Data = N> {
+    /// Returns the type of this node.
+    fn node_type(&self) -> types::NodeType;
+}
 
 /// A graph edge between two nodes.
 pub trait Edge<W, E>: GraphObject<Data = E> {
     /// Get the edge weight.
     fn weight(&self) -> W;
+    /// Returns the type of this edge.
+    fn edge_type(&self) -> types::EdgeType;
 }
 
 /// The Graph API
@@ -76,7 +81,6 @@ pub trait GraphWriter: Graph + GraphDataWriter {
         id: Id<Self::Edge>,
         from: &Id<Self::Node>,
         to: &Id<Self::Node>,
-        weight: Self::Weight,
         data: Data<Self::Edge>,
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,11 @@ pub trait Node<N>: GraphObject<Data = N> {
 }
 
 /// A graph edge between two nodes.
-pub trait Edge<W, E>: GraphObject<Data = E> {
+pub trait Edge<W, NodeId, E>: GraphObject<Data = E> {
+    /// The source node.
+    fn source(&self) -> &NodeId;
+    /// The target node
+    fn target(&self) -> &NodeId;
     /// Get the edge weight.
     fn weight(&self) -> W;
     /// Returns the type of this edge.
@@ -91,6 +95,15 @@ pub trait GraphWriter: Graph + GraphDataWriter {
     fn nodes_mut(&mut self) -> NodesMut<Self::Node>;
 }
 
+/// A graph with read-only access to edge and node data.
+pub trait GraphDataReader: Graph {
+    /// Return an immutable reference to an edge's data.
+    fn edge_data(&self, id: &Id<Self::Edge>) -> Option<&Data<Self::Edge>>;
+
+    /// Return an immutable reference to a node's data, to annotate the node.
+    fn node_data(&self, id: &Id<Self::Node>) -> Option<&Data<Self::Node>>;
+}
+
 /// A graph with mutable access to edge and node data.
 pub trait GraphDataWriter: Graph {
     /// Return a mutable reference to an edge's data, to annotate the edge.
@@ -117,7 +130,7 @@ pub trait Graph: Default {
     type Node: Node<Self::NodeData>;
 
     /// A graph edge between nodes.
-    type Edge: Edge<Self::Weight, Self::EdgeData>;
+    type Edge: Edge<Self::Weight, <Self::Node as GraphObject>::Id, Self::EdgeData>;
 
     /// Data stored in graph nodes.
     type NodeData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub trait GraphObject {
 /// A graph  node.
 pub trait Node<N>: GraphObject<Data = N> {
     /// Returns the type of this node.
-    fn node_type(&self) -> types::NodeType;
+    fn node_type(&self) -> &types::NodeType;
 }
 
 /// A graph edge between two nodes.
@@ -47,7 +47,7 @@ pub trait Edge<W, E>: GraphObject<Data = E> {
     /// Get the edge weight.
     fn weight(&self) -> W;
     /// Returns the type of this edge.
-    fn edge_type(&self) -> types::EdgeType;
+    fn edge_type(&self) -> &types::EdgeType;
 }
 
 /// The Graph API

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub trait GraphDataReader: Graph {
     /// Return an immutable reference to an edge's data.
     fn edge_data(&self, id: &Id<Self::Edge>) -> Option<&Data<Self::Edge>>;
 
-    /// Return an immutable reference to a node's data, to annotate the node.
+    /// Return an immutable reference to a node's data.
     fn node_data(&self, id: &Id<Self::Node>) -> Option<&Data<Self::Node>>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 ///! Graph API Traits
 pub mod types;
 
+use crate::types::EdgeType;
+
 /// Specifies a direction for an edge.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Direction {
@@ -248,6 +250,7 @@ pub struct EdgeRef<'a, NodeId, EdgeId> {
     pub from: &'a NodeId,
     pub to: &'a NodeId,
     pub id: &'a EdgeId,
+    pub edge_type: &'a EdgeType,
 }
 
 pub type EdgeRefs<'a, N, E> = Vec<EdgeRef<'a, N, E>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,14 @@ pub trait GraphObject {
 /// A graph  node.
 pub trait Node<N>: GraphObject<Data = N> {
     /// Returns the type of this node.
+    // NOTE(adinapoli) Here we are using the *concrete* `NodeType`, but
+    // at this stage it's unclear whether is useful/necessary to depend on the
+    // concrete type. That might be useful if the Registry & Osrank will agree
+    // on this same type and would require this to be the "lowest common
+    // denominator" when writing otherwise-polymorphic and abstract GraphAPI
+    // code. An alternative design could be remove this method and have
+    // library writers to use the `Data` here and require their functions to
+    // "known" how to convert from `Data` into a `NodeType`.
     fn node_type(&self) -> &types::NodeType;
 }
 
@@ -53,6 +61,7 @@ pub trait Edge<W, NodeId, E>: GraphObject<Data = E> {
     /// Get the edge weight.
     fn weight(&self) -> W;
     /// Returns the type of this edge.
+    // TODO(adinapoli) Same considerations as per `Node::node_type` apply.
     fn edge_type(&self) -> &types::EdgeType;
 }
 
@@ -250,6 +259,15 @@ pub struct EdgeRef<'a, NodeId, EdgeId> {
     pub from: &'a NodeId,
     pub to: &'a NodeId,
     pub id: &'a EdgeId,
+
+    // TODO(adinapoli) Here we are using the *concrete* `EdgeType`, because
+    // it's handy to get hold of the type of the edge for library consumers,
+    // without having to assume anything about the underlying structure of the
+    // edge's data. In this design we cannot use `G::EdgeData` directly, because
+    // we don't have a `G` in scope. A perhaps better design would be either to
+    // make `EdgeRef` polymorphic in `G` and use `Id<G::Node>` and `Id<G::Edge>`
+    // and have `edge_data: &'a G::EdgeData` or simply parameterise the `EdgeRef`
+    // from an additional `EdgeData/EdgeType` parameter.
     pub edge_type: &'a EdgeType,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[deny(clippy::all)]
 ///! Graph API Traits
+pub mod types;
 
 /// Specifies a direction for an edge.
 #[derive(Debug, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,13 @@
 //! Concrete node and edge types used in the registry.
 
+extern crate num_traits;
 extern crate quickcheck;
 
+use num_traits::Zero;
 use quickcheck::{Arbitrary, Gen};
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::ops::Add;
 
 /// The type of a node.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -64,7 +67,7 @@ pub enum EdgeType {
 }
 
 /// Edge data.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EdgeData<W> {
     /// The type for this edge.
     pub edge_type: EdgeType,
@@ -80,6 +83,29 @@ pub struct EdgeData<W> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NodeRank<W> {
     pub rank: W,
+}
+
+impl<W: Add<Output = W>> Add for NodeRank<W> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        NodeRank {
+            rank: self.rank + other.rank,
+        }
+    }
+}
+
+impl<W> Zero for NodeRank<W>
+where
+    W: Zero,
+{
+    fn zero() -> Self {
+        NodeRank { rank: W::zero() }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.rank.is_zero()
+    }
 }
 
 // FIXME(adn) If we really want precise *bounded* ranks, then we need to

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,13 +1,16 @@
 //! Concrete node and edge types used in the registry.
 
 extern crate num_traits;
+#[cfg(feature = "quickcheck")]
 extern crate quickcheck;
 
 use num_traits::Zero;
-use quickcheck::{Arbitrary, Gen};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Add;
+
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
 
 /// The type of a node.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -18,6 +21,7 @@ pub enum NodeType {
     Project,
 }
 
+#[cfg(feature = "quickcheck")]
 impl Arbitrary for NodeType {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         if g.next_u32() % 2 == 0 {
@@ -38,6 +42,7 @@ pub struct NodeData<W> {
     pub rank: NodeRank<W>,
 }
 
+#[cfg(feature = "quickcheck")]
 impl<W> Arbitrary for NodeData<W>
 where
     W: Arbitrary,
@@ -108,6 +113,7 @@ where
     }
 }
 
+#[cfg(feature = "quickcheck")]
 // TODO(adn) If we really want precise *bounded* ranks, then we need to
 // pull the `num::Bounded` trait from the `num` crate.
 impl<W> Arbitrary for NodeRank<W>

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,7 +52,7 @@ where
 }
 
 /// The type of an edge.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EdgeType {
     /// Contribution from a project to a user.
     Contrib,

--- a/src/types.rs
+++ b/src/types.rs
@@ -60,13 +60,13 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EdgeType {
     /// Contribution from a project to a user. Corresponds to `contrib` from the paper.
-    ContributionFromUser,
+    ProjectToUserContribution,
     /// Contribution from a user to a project. Corresponds to `contribᵒ` from the paper.
-    ContributionToProject,
-    /// Membership of a user in a project. Corresponds to `maintain` from the paper.
-    MaintenanceFromUser,
-    /// Membership of a user in a project. Correspond to `maintainᵒ` from the paper.
-    Maintenance,
+    UserToProjectContribution,
+    /// Membership relation from a project to a user. Corresponds to `maintain` from the paper.
+    ProjectToUserMembership,
+    /// Membership relation from a user to a project. Correspond to `maintainᵒ` from the paper.
+    UserToProjectMembership,
     /// One-way dependency between two projects. Correspond to `depend` from the paper.
     Dependency,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,16 +54,16 @@ where
 /// The type of an edge.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EdgeType {
-    /// Contribution from a project to a user.
-    Contrib,
-    /// Contribution from a user to a project.
-    ContribStar,
-    /// Membership of a user in a project, project -> user.
-    Maintain,
-    /// Membership of a user in a project, user -> project.
-    MaintainStar,
-    /// One-way dependency between two projects, project -> project.
-    Depend,
+    /// Contribution from a project to a user. Corresponds to `contrib` from the paper.
+    ContributionFromUser,
+    /// Contribution from a user to a project. Corresponds to `contribᵒ` from the paper.
+    ContributionToProject,
+    /// Membership of a user in a project. Corresponds to `maintain` from the paper.
+    MaintenanceFromUser,
+    /// Membership of a user in a project. Correspond to `maintainᵒ` from the paper.
+    Maintenance,
+    /// One-way dependency between two projects. Correspond to `depend` from the paper.
+    Dependency,
 }
 
 /// Edge data.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 //! Concrete node and edge types used in the registry.
 
+use std::collections::HashMap;
+
 /// The type of a node.
 pub enum NodeType {
     /// A user, eg. contributor, project member etc.
@@ -9,7 +11,10 @@ pub enum NodeType {
 }
 
 /// Node data.
-type NodeData = NodeType;
+pub struct NodeData {
+    /// The total contributions by this user, to *all* projects, if any.
+    pub total_contributions: Option<u32>,
+}
 
 /// The type of an edge.
 pub enum EdgeType {
@@ -23,29 +28,33 @@ pub enum EdgeType {
 }
 
 /// Edge data.
-pub struct EdgeData {
+pub struct EdgeData<W> {
     /// The type of edge.
-    edge_type: EdgeType,
+    pub edge_type: EdgeType,
     /// The weight of this specific edge. Can be used to weight for eg.
     /// edges with more contributions higher, or weigh certain dependencies
-    /// higher than others. Defaults to `1.0`.
-    weight: f64,
+    /// higher than others.
+    pub weight: W,
+    /// The contributions of the user towards a project, if any.
+    pub contributions: Option<u32>,
 }
 
 /// The rank or "osrank" of a node, normalized to `1.0`.
-pub type NodeRank = f64;
+pub struct NodeRank<W> {
+    pub rank: W,
+}
 
 /// Global parameters used by the graph algorithm.
-pub struct HyperParameters {
+pub struct HyperParameters<W> {
     /// Also `tau`. Threshold below which nodes are pruned in the first
     /// phase of the algorithm.
-    pruning_threshold: f64,
+    pub pruning_threshold: W,
     /// Probability that a random walk on a project node continues.
-    project_damping_factor: f64,
+    pub project_damping_factor: W,
     /// Probability that a random walk on a user node continues.
-    user_damping_factor: f64,
+    pub user_damping_factor: W,
     /// 'R' value.
-    r_value: f64,
+    pub r_value: u32,
     /// Weights for the different edge types.
-    edge_weights: HashMap<EdgeType, f64>,
+    pub edge_weights: HashMap<EdgeType, W>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,7 +108,7 @@ where
     }
 }
 
-// FIXME(adn) If we really want precise *bounded* ranks, then we need to
+// TODO(adn) If we really want precise *bounded* ranks, then we need to
 // pull the `num::Bounded` trait from the `num` crate.
 impl<W> Arbitrary for NodeRank<W>
 where
@@ -121,18 +121,34 @@ where
     }
 }
 
+/// Global DampingFactors used by the graph algorithm.
+#[derive(Clone, Debug)]
+pub struct DampingFactors {
+    /// Probability that a random walk on a project node continues.
+    pub project: f64,
+    /// Probability that a random walk on a user node continues.
+    pub account: f64,
+}
+
 /// Global parameters used by the graph algorithm.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HyperParameters<W> {
     /// Also `tau`. Threshold below which nodes are pruned in the first
     /// phase of the algorithm.
     pub pruning_threshold: W,
-    /// Probability that a random walk on a project node continues.
-    pub project_damping_factor: W,
-    /// Probability that a random walk on a user node continues.
-    pub user_damping_factor: W,
+    pub damping_factors: DampingFactors,
     /// 'R' value.
     pub r_value: u32,
     /// Weights for the different edge types.
     pub edge_weights: HashMap<EdgeType, W>,
+}
+
+impl<W> HyperParameters<W> {
+    /// Get the hyper value associated to the input `EdgeType`. It panics at
+    /// runtime if the value cannot be found.
+    pub fn get_param(&self, edge_type: &EdgeType) -> &W {
+        self.edge_weights
+            .get(edge_type)
+            .unwrap_or_else(|| panic!("hyperparam value for {:#?} not found.", edge_type))
+    }
 }


### PR DESCRIPTION
In my quest to fix osrank-rs#85, I have generalised some types to accept a polymorphic `W`, so that we can instantiate this on the `osrank-rs` side with either a proper fractional type (for testing) for with a `f64` (for production).

On top of that, I have also added a bunch of `Arbitrary` instances which we need in the tests.

The most controversial change might be the changes to the `EdgeType` type, which has now been modelled not in terms of the "entity-relational" high-level schema, but in terms of the "low-level" osrank representation. There are two reasons behind this change:

1. The previous `edge_weights: HashMap<EdgeType, f64>` was incorrect, because the paper defines 5 distinct weights (`depend`, `contrib`, `contrib*`, `maintain`, `maintain*`) but due to the fact the cardinality of the previous `EdgeType` was 3, we couldn't store all the hyperparams correctly;

2. We can always recover the previous notion of "high-level types" by having simple helper functions which can be called from the ledger to set the correct edge type which can get "desugared" into the low-level `EdgeType`. Practical example: we could have `add_edge_foobar(n1: Node, n2: Node, ...)` which would look at the `NodeType` of `n1` and `n2` and determine the right edge type.

Early feedback welcome! I should also say that all the changes I am making here and being driven by `osrank-rs`.